### PR TITLE
Update Python Version and Mamba version to prevent commit failure

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Set up miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        mamba-version: "*"
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
         channels: conda-forge,defaults
         channel-priority: true
         auto-update-conda: true

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: build
 
 on: [push]
 env:
-  PYTHON_VERSION: 3.6.7
+  PYTHON_VERSION: 3.11.1
 
 jobs:
   testing:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: build
 
 on: [push]
 env:
-  PYTHON_VERSION: 3.6
+  PYTHON_VERSION: 3.6.7
 
 jobs:
   testing:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -2,7 +2,7 @@ name: build
 
 on: [push]
 env:
-  PYTHON_VERSION: 3.11.1
+  PYTHON_VERSION: 3.9
 
 jobs:
   testing:
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python ${{env.PYTHON_VERSION}}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v1
       with:
         python-version: ${{env.PYTHON_VERSION}}
     - name: Set up miniconda

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Set up Python ${{env.PYTHON_VERSION}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{env.PYTHON_VERSION}}
     - name: Set up miniconda

--- a/src/scripts/run_snakemake.sh
+++ b/src/scripts/run_snakemake.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# test for mamba error
+
 usage() { 
     local err=${1:-""};
     cat <<EOF

--- a/src/scripts/run_snakemake.sh
+++ b/src/scripts/run_snakemake.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+# test for mamba error
 usage() { 
     local err=${1:-""};
     cat <<EOF


### PR DESCRIPTION
Following @TedBrookings comments in fulcrum-core I tried replicating his errors and noticed that attempting to push commits to `python-snakemake-skeleton` rendered the following error: 

`testing
The version '3.6' with architecture 'x64' was not found for Ubuntu 22.04. The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json`

To fix this, `PYTHON_VERSION` must be set to 3.9. Then, the expected mamba setup error occurred during the commit process:

`testing
The process '/usr/share/miniconda/condabin/conda' failed with exit code 1`

This is fixed by changing 
`mamba-version: "*"`
 to 
`miniforge-variant: Mambaforge`
`miniforge-version: latest` in pythonpackage.yml. 

These are small changes that will hopefully prevent future fulcrum members from experiencing failures during the commit process. 